### PR TITLE
Allow editing products, add plans and subscriptions

### DIFF
--- a/payments/stripe.lua
+++ b/payments/stripe.lua
@@ -307,9 +307,6 @@ do
   resource("refunds", {
     edit = false
   })
-  resource("products", {
-    edit = false
-  })
   resource("transfers", {
     edit = false
   })
@@ -327,6 +324,9 @@ do
     edit = false,
     path = "bitcoin/receivers"
   })
+  resource("products")
+  resource("plans")
+  resource("subscriptions")
   if _parent_0.__inherited then
     _parent_0.__inherited(_parent_0, _class_0)
   end

--- a/payments/stripe.moon
+++ b/payments/stripe.moon
@@ -205,12 +205,15 @@ class Stripe extends require "payments.base_client"
   resource "charges", edit: false
   resource "disputes", edit: false
   resource "refunds", edit: false
-  resource "products", edit: false
   resource "transfers", edit: false
   resource "balance_transactions", edit: false, path: "balance/history"
   resource "application_fees", edit: false
   resource "events", edit: false
   resource "bitcoin_receivers", edit: false, path: "bitcoin/receivers"
+
+  resource "products"
+  resource "plans"
+  resource "subscriptions"
 
   -- charge a card with amount cents
   -- TODO: replace this with resource


### PR DESCRIPTION
N.B: in newer Stripe API versions, "products" is used both for one-time sales and for recurring billing.